### PR TITLE
Fixing method for getting correct hrefs for child pages

### DIFF
--- a/code/Pages/SiteMapPage.php
+++ b/code/Pages/SiteMapPage.php
@@ -63,7 +63,7 @@ class SiteMapPage_Controller extends Page_Controller
             $li->a->addAttribute('href', $page->Link);
 
             // check if the page has children and if so output them
-            $kids = SiteTree::get()->filter('ParentID', $page->ID);
+            $kids = $page->Children();
             foreach ($kids as $subPage) {
                 $this->processPageToHierarchicalHTML(
                     $li,


### PR DESCRIPTION
During commit 3fc128da5... the method for getting the children of page changed, which only retrieve top level children, thus breaking the sitemap by providing the wrong href for links. This restores the old method, fixing the hrefs for child pages. 